### PR TITLE
Add stylelint as a dependency and other minor devdeps update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
-    "del": "^4.0.0",
+    "del": "^4.1.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^6.1.0",
     "gulp-cssimport": "^7.0.0",
     "gulp-header": "^2.0.7",
     "gulp-load-plugins": "^1.6.0",
+    "stylelint": "^10.1.0",
     "stylelint-config-recommended": "^2.2.0"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "babel-preset-env": "^1.7.0",
     "del": "^4.0.0",
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^6.0.0",
+    "gulp-autoprefixer": "^6.1.0",
     "gulp-cssimport": "^7.0.0",
     "gulp-header": "^2.0.7",
-    "gulp-load-plugins": "^1.5.0",
-    "stylelint-config-recommended": "^2.1.0"
+    "gulp-load-plugins": "^1.6.0",
+    "stylelint-config-recommended": "^2.2.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
bumps minor updates to: gulp-autoprefixer, gulp-load-plugins, stylelint-config-recommended