### PR TITLE
Update _helpers.css

### DIFF
--- a/src/_helpers.css
+++ b/src/_helpers.css
@@ -61,18 +61,13 @@
 /*
  * Clearfix: contain floats
  *
- * For modern browsers
- * 1. The space content is one way to avoid an Opera bug when the
- *    `contenteditable` attribute is included anywhere else in the document.
- *    Otherwise it causes space to appear at the top and bottom of elements
- *    that receive the `clearfix` class.
- * 2. The use of `table` rather than `block` is only necessary if using
- *    `:before` to contain the top-margins of child elements.
+ * The use of `table` rather than `block` is only necessary if using
+ * `::before` to contain the top-margins of child elements.
  */
 
 .clearfix::before,
 .clearfix::after {
-  content: " ";
+  content: "";
   display: table;
 }
 


### PR DESCRIPTION
The ``contenteditable``/clearfix workaround is no longer necessary for Opera/Presto.

Confirmed in Opera Mini for Android using Extreme Mode (which still uses the Presto rendering engine): https://codepen.io/mattbrundage/pen/rNOgPPr

More info on Opera Mini rendering modes: https://dev.opera.com/articles/browsers-modes-engines/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

