### PR TITLE
chore: dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      time: "03:00"
     open-pull-requests-limit: 10
+    versioning-strategy: increase


### PR DESCRIPTION
To match:
https://github.com/h5bp/create-html5-boilerplate/blob/master/.github/dependabot.yml
https://github.com/h5bp/html5-boilerplate/blob/master/.github/dependabot.yml
