### PR TITLE
Remove print thead rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ At printing time, these styles will:
   [supporting browsers](https://en.wikipedia.org/wiki/Comparison_of_layout_engines_%28Cascading_Style_Sheets%29#Grammar_and_rules)
   that they should:
 
-  - ensure the table header (`<thead>`) is [printed on each page spanned by the
-    table](https://web.archive.org/web/20180815150934/http://css-discuss.incutio.com/wiki/Printing_Tables)
   - prevent block quotations, preformatted text, images and table rows from
     being split onto two different pages
   - ensure that headings never appear on a different page than the text they

--- a/src/_print.css
+++ b/src/_print.css
@@ -47,14 +47,6 @@
     page-break-inside: avoid;
   }
 
-  /*
-   * Printing Tables:
-   * https://web.archive.org/web/20180815150934/http://css-discuss.incutio.com/wiki/Printing_Tables
-   */
-  thead {
-    display: table-header-group;
-  }
-
   tr,
   img {
     page-break-inside: avoid;


### PR DESCRIPTION
The ``thead`` rule is safe to remove -- it was a workaround for browsers that didn't conform to this part of the CSS 2.1 spec. (https://www.w3.org/TR/CSS21/tables.html#table-display)
In practice, this meant IE 6 & IE 7.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

